### PR TITLE
chore: improve activity stream and deployments list

### DIFF
--- a/app/views/admin/instance_access/activity_stream.html.erb
+++ b/app/views/admin/instance_access/activity_stream.html.erb
@@ -1,33 +1,32 @@
 <section>
-  <h1 class="h3 mb-3 text-gray-800 mt-3">Activity Stream</h1>
+  <h3 class="mb-3 text-gray-800 mt-3">Activity Stream</h1>
 </section>
 <section>
   <div class="row">
     <div class="col-lg-9">
       <div id="admin-instance-activity-stream">
-        <section>
-          <div class='row'>
-            <% @events.each do |event| %>
-              <div class='col-lg-12 col-sm-6 mb-2'>
-                <div class="card card-instance-details">
-                  <div class='card-body'>
-                    <div class="row">
-                      <div class='col-lg-10 col-sm-10'>
-                        <i class="fa fa-clock"></i>
-                        <!--TODO - <b><%= event['user'] %></b>-->
-                        <%= link_to event.dig('obj', 'title'), action: :event, event_id: event['id'] %>
-                      </div>
-                      <div class='col-lg-2 col-sm-2text-right'>
-                        <i class="fa fa-clock"></i>
-                        <%= event['created_at'] %> <br /><%= time_ago_in_words(event['created_at']) %> ago
-                      </div>
+        <div class="row">
+          <% @events.each do |event| %>
+            <div class="col-lg-12 col-sm-6 mb-2">
+              <div class="card card-instance-details">
+                <div class="card-body">
+                  <div class="row">
+                    <div class="col-sm-6">
+                      <i class="fa fa-clock"></i>
+                      <!--TODO - <b><%= event['user'] %></b>-->
+                      <%= link_to event.dig('obj', 'title'), action: :event, event_id: event['id'] %>
+                    </div>
+                    <div class="col-sm-6 text-right">
+                      <i class="fa fa-clock"></i>
+                      <%= time_ago_in_words(event['created_at']) %> ago<br>
+                      <%= event['created_at'] %>
                     </div>
                   </div>
                 </div>
               </div>
-            <% end %>
-          </div>
-        </section>
+            </div>
+          <% end %>
+        </div>
       </div>
     </div>
     <div class="col-lg-3">

--- a/app/views/admin/instance_access/deployments.html.erb
+++ b/app/views/admin/instance_access/deployments.html.erb
@@ -1,60 +1,53 @@
 <section>
-  <h1 class="h3 mb-3 text-gray-800 mt-3">
-    Deployments
-  </h1>
+  <h3 class="mb-3 text-gray-800 mt-3">Deployments</h1>
 </section>
 <section>
   <div class="row">
     <div class="col-lg-9">
       <div id="admin-instance-deployments">
-        <section>
-          <% if @deployments == [] %>
-            <div>
-              <p><b>No deployment history available.</b></p>
+        <% if @deployments == [] %>
+          <div>
+            <p><b>No deployment history available.</b></p>
 
-              <p>Get started now with our CLI, see the <a href="/docs/platform/">relevant documentation</a>. Do not hesitate to <a href="/admin/support">contact us!</a></p>
-            </div>
-          <% end %>
+            <p>Get started now with our CLI, see the <a href="/docs/platform/">relevant documentation</a>. Do not hesitate to <a href="/admin/support">contact us!</a></p>
+          </div>
+        <% end %>
 
-          <div class='row'>
-            <% @deployments.each do |deployment| %>
-              <div class='col-lg-12 col-sm-6 mb-2'>
-                <div class="card card-instance-details">
-                  <div class='card-body'>
-                    <div class="row">
-                      <div class='col-lg-4 col-sm-4'>
-                        <i class="fa fa-globe-americas"></i> 
-                        <%= link_to deployment['type'],
-                                    admin_instance_access_deployment_path(deployment_id: deployment['id']) %>
-                      </div>
-                      <div class='col-lg-6 col-sm-6'>
-                        <span class="badge badge-<%= deployment_status_to_level(deployment['status']) %>">
-                          <%= deployment['status'] %>
+        <div class="row">
+          <% @deployments.each do |deployment| %>
+            <div class="col-lg-12 col-sm-6 mb-2">
+              <div class="card card-instance-details">
+                <div class="card-body">
+                  <div class="row">
+                    <div class="col-sm-6">
+                      <i class="fa fa-globe-americas"></i> 
+                      <%= link_to deployment['type'],
+                                  admin_instance_access_deployment_path(deployment_id: deployment['id']) %><br>
+                      <span class="badge badge-<%= deployment_status_to_level(deployment['status']) %>">
+                        <%= deployment['status'] %>
+                      </span>
+                      <% if deployment['status'] == 'success' &&
+                            deployment&.dig('obj', 'image_name_tag') %>
+                        <span>
+                          <%= link_to 'Rollback',
+                                      "#{admin_instance_access_rollback_deployment_path(deployment_id: deployment['id'])}",
+                            class: 'btn btn-sm btn-outline-dark',
+                            method: :post,
+                            data: { confirm: "Are you sure?" } %>
                         </span>
-                        
-                      </div>
-                      <div class='col-lg-2 col-sm-2text-right'>
-                        <i class="fa fa-clock"></i>
-                        <%= time_ago_in_words(deployment['created_at']) %> ago
-
-                        <% if deployment['status'] == 'success' &&
-                              deployment&.dig('obj', 'image_name_tag') %>
-                          <div>
-                            <%= link_to 'Rollback',
-                                        "#{admin_instance_access_rollback_deployment_path(deployment_id: deployment['id'])}",
-                              class: 'btn btn-sm btn-outline-dark',
-                              method: :post,
-                              data: { confirm: "Are you sure?" } %>
-                          </div>
-                        <% end %>
-                      </div>
+                      <% end %>
+                    </div>
+                    <div class="col-sm-6 text-right">
+                      <i class="fa fa-clock"></i>
+                      <%= time_ago_in_words(deployment['created_at']) %> ago<br>
+                      <%= deployment.created_at %>
                     </div>
                   </div>
                 </div>
               </div>
-            <% end %>
-          </div>
-        </section>
+            </div>
+          <% end %>
+        </div>
       </div>
     </div>
     <div class="col-lg-3">

--- a/app/views/admin/instances/access/_activity_stream.html.erb
+++ b/app/views/admin/instances/access/_activity_stream.html.erb
@@ -1,22 +1,22 @@
 <div id="admin-instance-activity-stream">
-  <section>
-    <div class='row'>
-      <% activities.each do |activity| %>
-        <div class='col-lg-12 col-sm-6 mb-2'>
-          <div class="card card-instance-details">
-            <div class='card-body'>
-              <div class="row">
-                <div class='col-lg-10 col-sm-10'>
-                  <i class="fa fa-clock"></i> <b><%= activity.user %></b> <%= activity.message %>
-                </div>
-                <div class='col-lg-2 col-sm-2text-right'>
-                  <i class="fa fa-clock"></i> <%= time_ago_in_words(activity.date) %> ago
-                </div>
+  <div class="row">
+    <% activities.each do |activity| %>
+      <div class="col-lg-12 col-sm-6 mb-2">
+        <div class="card card-instance-details">
+          <div class="card-body">
+            <div class="row">
+              <div class="col-sm-6">
+                <i class="fa fa-clock"></i> <b><%= activity.user %></b> <%= activity.message %>
+              </div>
+              <div class="col-sm-6 text-right">
+                <i class="fa fa-clock"></i>
+                <%= time_ago_in_words(activity.date) %> ago<br>
+                <%= activity.created_at %>
               </div>
             </div>
           </div>
         </div>
-      <% end %>
-    </div>
-  </section>
+      </div>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
## Changes
- changed `<h1 class="h3...">` to a h3, since there is already a h1 defined before and the styles are the same
- removed unused section inside the list
- changed single quotes to double quotes to be consistent
- enhanced table list width: for activity stream it's now 2 lines instead of 3
- deployments: moved status and rollback button below the event name
- added created_at to deployment
- text-right fix (missing whitespace)
- smaller changes

Regarding code like `col-lg-4 col-sm-4` this can be simplified with `col-sm-4`
> Grid breakpoints are based on minimum width media queries, meaning they apply to that one breakpoint and all those above it (e.g., .col-sm-4 applies to small, medium, large, and extra large devices, but not the first xs breakpoint).
(https://getbootstrap.com/docs/4.6/layout/grid/#how-it-works)